### PR TITLE
RavenJSONUtilities.m no longer needs -fno-objc-arc

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ raven-objc uses [`NSJSONSerialization`](http://developer.apple.com/library/mac/#
 
 ### ARC Support
 
-raven-objc requires ARC support and should run on iOS 4.0 and higher. However, `RavenJSONUtilities.m` needs to be compiled with the `-fno-objc-arc` flag. To do this in Xcode, go to your active target and select the "Build Phases" tab. In the "Compiler Flags" column, set `-fno-objc-arc` for `RavenJSONUtilities.m`.
+raven-objc requires ARC support and should run on iOS 4.0 and higher.
 
 ## Issues and questions
 


### PR DESCRIPTION
![screen shot 2013-06-27 at 9 04 44 pm](https://f.cloud.github.com/assets/1382511/720022/ea2a9918-dfa7-11e2-84aa-48d4c1377245.png)
