### PR TITLE
Use sentry protocol v4 instead of v2 ; send tags and an 'extra' dictionary with the events

### DIFF
--- a/Raven/RavenClient.h
+++ b/Raven/RavenClient.h
@@ -21,15 +21,18 @@ typedef enum {
 
 @interface RavenClient : NSObject <NSURLConnectionDelegate>
 
+@property (strong, nonatomic) NSDictionary *extra;
 @property (strong, nonatomic) NSDictionary *tags;
 
 // Singleton and initializers
 + (RavenClient *)clientWithDSN:(NSString *)DSN;
-+ (RavenClient *)clientWithDSN:(NSString *)DSN andTags:(NSDictionary *)tags;
++ (RavenClient *)clientWithDSN:(NSString *)DSN extra:(NSDictionary *)extra;
++ (RavenClient *)clientWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags;
 + (RavenClient *)sharedClient;
 
 - (id)initWithDSN:(NSString *)DSN;
-- (id)initWithDSN:(NSString *)DSN andTags:(NSDictionary *)tags;
+- (id)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra;
+- (id)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags;
 
 // Messages
 - (void)captureMessage:(NSString *)message;

--- a/Raven/RavenClient_Private.h
+++ b/Raven/RavenClient_Private.h
@@ -17,6 +17,11 @@
 @property (strong, nonatomic) RavenConfig *config;
 
 - (NSString *)generateUUID;
+- (NSDictionary *)prepareDictionaryForMessage:(NSString *)message
+                                        level:(RavenLogLevel)level
+                                      culprit:(NSString *)culprit
+                                   stacktrace:(NSArray *)stacktrace
+                                    exception:(NSDictionary *)exceptionDict;
 - (void)sendDictionary:(NSDictionary *)dict;
 - (void)sendJSON:(NSData *)JSON;
 

--- a/RavenTests/RavenClientTest.m
+++ b/RavenTests/RavenClientTest.m
@@ -8,6 +8,8 @@
 
 #import "RavenClientTest.h"
 
+NSString *const testDSN = @"http://public:secret@example.com/foo";
+
 @implementation MockRavenClient
 
 - (void)sendDictionary:(NSDictionary *)dict
@@ -24,7 +26,7 @@
 {
     [super setUp];
 
-    self.client = [[MockRavenClient alloc] initWithDSN:@"http://public:secret@example.com/foo"];
+    self.client = [[MockRavenClient alloc] initWithDSN:testDSN];
 }
 
 - (void)tearDown
@@ -99,6 +101,26 @@
                  @"Invalid value for level: %@", [lastEvent valueForKey:@"level"]);
     STAssertEquals([lastEvent valueForKey:@"platform"], @"objc",
                    @"Invalid value for platform: %@", [lastEvent valueForKey:@"platform"]);
+}
+
+- (void)testClientWithExtraAndTags
+{
+    NSDictionary *extra = [NSDictionary dictionaryWithObjectsAndKeys:@"value", @"key", nil];
+    NSDictionary *tags = [NSDictionary dictionaryWithObjectsAndKeys:@"value", @"key", nil];
+
+    MockRavenClient *client = [[MockRavenClient alloc] initWithDSN:testDSN extra:extra tags:tags];
+    [client captureMessage:@"An example message"];
+
+    NSDictionary *lastEvent = client.lastEvent;
+    NSArray *keys = [lastEvent allKeys];
+
+    STAssertTrue([keys containsObject:@"extra"], @"Missing extra");
+    STAssertTrue([keys containsObject:@"tags"], @"Missing tags");
+    STAssertEquals([[lastEvent objectForKey:@"extra"] objectForKey:@"key"], @"value", @"Missing extra data");
+    STAssertEquals([[lastEvent objectForKey:@"tags"] objectForKey:@"key"], @"value", @"Missing tags data");
+
+    STAssertNotNil([[lastEvent objectForKey:@"tags"] objectForKey:@"OS version"], @"Missing tags data");
+    STAssertNotNil([[lastEvent objectForKey:@"tags"] objectForKey:@"Device model"], @"Missing tags data");
 }
 
 @end


### PR DESCRIPTION
`tags` parameter: I picked up #18 and #20 and refactored the code to be retro-compatible. (so auto tagging of the build version, OS and device model)

`extra` parameter: I moved the stacktrace from the extra key to the `stacktrace` sentry module which leave available the `extra` parameter for custom data (user id, …).

using this version on a real project with no problem, all test are passing :)

Arthur
