### PR TITLE
Send request asynchronously and drop the response

### DIFF
--- a/Raven/RavenClient.h
+++ b/Raven/RavenClient.h
@@ -19,7 +19,7 @@ typedef enum {
 } RavenLogLevel;
 
 
-@interface RavenClient : NSObject <NSURLConnectionDelegate>
+@interface RavenClient : NSObject
 
 @property (strong, nonatomic) NSDictionary *extra;
 @property (strong, nonatomic) NSDictionary *tags;

--- a/Raven/RavenClient.m
+++ b/Raven/RavenClient.m
@@ -307,28 +307,7 @@ void exceptionHandler(NSException *exception) {
     [request setHTTPBody:JSON];
     [request setValue:header forHTTPHeaderField:@"X-Sentry-Auth"];
 
-    NSURLConnection *connection = [NSURLConnection connectionWithRequest:request delegate:self];
-    if (connection) {
-        self.receivedData = [NSMutableData data];
-    }
-}
-
-#pragma mark - NSURLConnectionDelegate
-
-- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
-    [self.receivedData setLength:0];
-}
-
-- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
-    [self.receivedData appendData:data];
-}
-
-- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
-    NSLog(@"Connection failed! Error - %@ %@", [error localizedDescription], [[error userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey]);
-}
-
-- (void)connectionDidFinishLoading:(NSURLConnection *)connection {
-    NSLog(@"JSON sent to Sentry");
+    [NSURLConnection sendAsynchronousRequest:request queue:[NSOperationQueue currentQueue] completionHandler:nil];
 }
 
 @end

--- a/Raven/RavenClient_Private.h
+++ b/Raven/RavenClient_Private.h
@@ -13,7 +13,6 @@
 @interface RavenClient ()
 
 @property (strong, nonatomic) NSDateFormatter *dateFormatter;
-@property (strong, nonatomic) NSMutableData *receivedData;
 @property (strong, nonatomic) RavenConfig *config;
 
 - (NSString *)generateUUID;


### PR DESCRIPTION
Send the request asynchronously. We also do not give a response callback since we don't do anything with it.

This also allows to send messages from any thread. Previously, if you sent a message from a queue that is deleted right after the call, the message was not sent.
