### PR TITLE
Added a better culprit description

### DIFF
--- a/Raven/RavenClient.m
+++ b/Raven/RavenClient.m
@@ -152,21 +152,26 @@ void exceptionHandler(NSException *exception) {
                   file:(const char *)file
                   line:(NSInteger)line {
     NSArray *stacktrace;
+    NSString *culprit;
     if (method && file && line) {
+        NSString *filename = [[NSString stringWithUTF8String:file] lastPathComponent];
+        NSString *methodString = [NSString stringWithUTF8String:method];
         NSDictionary *frame = [NSDictionary dictionaryWithObjectsAndKeys:
-                               [[NSString stringWithUTF8String:file] lastPathComponent], @"filename",
-                               [NSString stringWithUTF8String:method], @"function",
+                               filename, @"filename",
+                               methodString, @"function",
                                [NSNumber numberWithInt:line], @"lineno",
                                nil];
 
         stacktrace = [NSArray arrayWithObject:frame];
+
+        culprit = [NSString stringWithFormat:@"%@ / %@", filename, methodString];
     }
 
     NSDictionary *data = [self prepareDictionaryForMessage:message
                                                      level:level
                                            additionalExtra:additionalExtra
                                             additionalTags:additionalTags
-                                                   culprit:file ? [NSString stringWithUTF8String:file] : nil
+                                                   culprit:culprit
                                                 stacktrace:stacktrace
                                                  exception:nil];
 


### PR DESCRIPTION
Instead of having the full path (including /User/username/...)m we show the filename and the method name
