### PR TITLE
connectionWithRequest:delegate: was causing 400 responses

### DIFF
--- a/Raven/RavenClient.h
+++ b/Raven/RavenClient.h
@@ -19,7 +19,7 @@ typedef enum {
 } RavenLogLevel;
 
 
-@interface RavenClient : NSObject <NSURLConnectionDelegate>
+@interface RavenClient : NSObject
 
 @property (strong, nonatomic) NSDictionary *extra;
 @property (strong, nonatomic) NSDictionary *tags;

--- a/Raven/RavenClient.m
+++ b/Raven/RavenClient.m
@@ -306,29 +306,15 @@ void exceptionHandler(NSException *exception) {
     [request setValue:[NSString stringWithFormat:@"%d", [JSON length]] forHTTPHeaderField:@"Content-Length"];
     [request setHTTPBody:JSON];
     [request setValue:header forHTTPHeaderField:@"X-Sentry-Auth"];
-
-    NSURLConnection *connection = [NSURLConnection connectionWithRequest:request delegate:self];
-    if (connection) {
-        self.receivedData = [NSMutableData data];
-    }
-}
-
-#pragma mark - NSURLConnectionDelegate
-
-- (void)connection:(NSURLConnection *)connection didReceiveResponse:(NSURLResponse *)response {
-    [self.receivedData setLength:0];
-}
-
-- (void)connection:(NSURLConnection *)connection didReceiveData:(NSData *)data {
-    [self.receivedData appendData:data];
-}
-
-- (void)connection:(NSURLConnection *)connection didFailWithError:(NSError *)error {
-    NSLog(@"Connection failed! Error - %@ %@", [error localizedDescription], [[error userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey]);
-}
-
-- (void)connectionDidFinishLoading:(NSURLConnection *)connection {
-    NSLog(@"JSON sent to Sentry");
+    
+    [NSURLConnection sendAsynchronousRequest:request queue:[NSOperationQueue currentQueue] completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
+        if (data) {
+            self.receivedData = data;
+        } else {
+             NSLog(@"Connection failed! Error - %@ %@", [connectionError localizedDescription], [[connectionError userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey]);
+            self.receivedData = nil;
+        }
+    }];
 }
 
 @end

--- a/Raven/RavenClient_Private.h
+++ b/Raven/RavenClient_Private.h
@@ -12,8 +12,8 @@
 
 @interface RavenClient ()
 
+@property (strong, nonatomic) NSData *receivedData;
 @property (strong, nonatomic) NSDateFormatter *dateFormatter;
-@property (strong, nonatomic) NSMutableData *receivedData;
 @property (strong, nonatomic) RavenConfig *config;
 
 - (NSString *)generateUUID;


### PR DESCRIPTION
I was receiving HTTP 400 responses when using the `connectionWithRequest:delegate:`, however when I switched to `sendAsynchronousRequest:queue:completionHandler:` I'm seeing successful responses.

One caveat is that  `sendAsynchronousRequest:queue:completionHandler:` is only available starting with OS X v10.7 and iOS 5.0.
