### PR TITLE
Support for offline network error logging

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Arthur Darcet- https://github.com/arthurdarcet
 lesterkp - https://github.com/lesterkp
 Christoph Lupprich - https://github.com/clupprich
 Dmitry Vorobyov - https://github.com/dvor
+Mark Anderson - https://github.com/manderson-productions

--- a/Raven/RavenClient.h
+++ b/Raven/RavenClient.h
@@ -18,6 +18,15 @@
                                                                        file:__FILE__ \
                                                                        line:__LINE__];
 
+#define RavenCaptureNetworkError(error) [[RavenClient sharedClient] captureMessage:[NSString stringWithFormat:@"%@", error] \
+                                                                             level:kRavenLogLevelDebugError \
+                                                                   additionalExtra:nil \
+                                                                    additionalTags:nil \
+                                                                            method:__FUNCTION__ \
+                                                                              file:__FILE__ \
+                                                                              line:__LINE__ \
+                                                                           sendNow:NO];
+
 #define RavenCaptureException(exception) [[RavenClient sharedClient] captureException:exception method:__FUNCTION__ file:__FILE__ line:__LINE__ sendNow:YES];
 
 
@@ -78,6 +87,15 @@ typedef enum {
                 method:(const char *)method
                   file:(const char *)file
                   line:(NSInteger)line;
+
+- (void)captureMessage:(NSString *)message
+                 level:(RavenLogLevel)level
+       additionalExtra:(NSDictionary *)additionalExtra
+        additionalTags:(NSDictionary *)additionalTags
+                method:(const char *)method
+                  file:(const char *)file
+                  line:(NSInteger)line
+               sendNow:(BOOL)sendNow;
 
 /**
  * Exceptions


### PR DESCRIPTION
I needed to support network error logging for Sentry (non-fatal exceptions that occurred due to some kind of network NSError). In most cases it makes sense to save these error reports until the next time the user starts up the app. Otherwise, the errors never get logged.

I am using the same methodology as from the exception reporting. RavenCaptureError() still maintains the same functionality as before, but the new macro RavenCaptureNetworkError() assumes that the network is not accessible, so we save the 'message/error' in the NSUSerDefaults reports until the next time the user launches the app.
