### PR TITLE
Fixed one more Implicit conversion: NSInteger -> int

### DIFF
--- a/Raven/RavenClient.m
+++ b/Raven/RavenClient.m
@@ -277,7 +277,7 @@ void exceptionHandler(NSException *exception) {
         NSDictionary *frame = [NSDictionary dictionaryWithObjectsAndKeys:
                 [[NSString stringWithUTF8String:file] lastPathComponent], @"filename",
                 [NSString stringWithUTF8String:method], @"function",
-                [NSNumber numberWithInt:line], @"lineno",
+                [NSNumber numberWithInteger:line], @"lineno",
                         nil];
 
         stacktrace = [NSMutableArray arrayWithObject:frame];


### PR DESCRIPTION
Probably forgotten in
https://github.com/getsentry/raven-objc/commit/f4badf189d256d723426bdb7aa52b7bf8776ca95
because it did fix the other occurence
