### PR TITLE
Do not set the singleton inside init

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,17 @@ While you are free to initialize as many instances of `RavenClient` as is approp
 #import "RavenClient.h"
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [RavenClient clientWithDSN:@"[SENTRY_DSN]"];
+    RavenClient *client = [RavenClient clientWithDSN:@"[SENTRY_DSN]"];
     // [...]
     return YES;
 }
 ```
-The first `RavenClient` that is initialized is automatically configured as the singleton instance and becomes available via the `sharedClient` singleton method:
+If you would like to use the singleton pattern, you can set the shared client that is used with the
+`+[setSharedClient:]` class method. After setting a client, you can retreive the singleton instance via
+the `sharedClient` singleton method:
 
 ```objective-c
+[RavenClient setSharedClient:client];
 NSLog(@"I am your RavenClient singleton : %@", [RavenClient sharedClient]);
 ```
 
@@ -61,8 +64,8 @@ Setup a global exception handler:
 
 ```objective-c
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [RavenClient clientWithDSN:@"https://[public]:[secret]@[server]/[project id]"];
-    [[RavenClient sharedClient] setupExceptionHandler];
+    RavenClient *client = [RavenClient clientWithDSN:@"https://[public]:[secret]@[server]/[project id]"];
+    [client setupExceptionHandler];
     // [...]
     return YES;
 }

--- a/Raven/RavenClient.h
+++ b/Raven/RavenClient.h
@@ -61,12 +61,14 @@ typedef enum {
 + (RavenClient *)clientWithDSN:(NSString *)DSN extra:(NSDictionary *)extra;
 + (RavenClient *)clientWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags;
 + (RavenClient *)clientWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags logger:(NSString *)logger;
-+ (RavenClient *)sharedClient;
 
-- (id)initWithDSN:(NSString *)DSN;
-- (id)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra;
-- (id)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags;
-- (id)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags logger:(NSString *)logger;
++ (instancetype)sharedClient;
++ (void)setSharedClient:(RavenClient *)client;
+
+- (instancetype)initWithDSN:(NSString *)DSN;
+- (instancetype)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra;
+- (instancetype)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags;
+- (instancetype)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags logger:(NSString *)logger;
 
 /**
  * Messages

--- a/Raven/RavenClient.m
+++ b/Raven/RavenClient.m
@@ -98,19 +98,23 @@ void exceptionHandler(NSException *exception) {
     return sharedClient;
 }
 
-- (id)initWithDSN:(NSString *)DSN {
++ (void)setSharedClient:(RavenClient *)client {
+    sharedClient = client;
+}
+
+- (instancetype)initWithDSN:(NSString *)DSN {
     return [self initWithDSN:DSN extra:@{}];
 }
 
-- (id)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra {
+- (instancetype)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra {
     return [self initWithDSN:DSN extra:extra tags:@{}];
 }
 
-- (id)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags {
+- (instancetype)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags {
     return [self initWithDSN:DSN extra:extra tags:tags logger:nil];
 }
 
-- (id)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags logger:(NSString *)logger {
+- (instancetype)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags logger:(NSString *)logger {
     self = [super init];
     if (self) {
 		_config = [[RavenConfig alloc] init];
@@ -122,11 +126,6 @@ void exceptionHandler(NSException *exception) {
         if (![_config setDSN:DSN]) {
             NSLog(@"Invalid DSN %@!", DSN);
             return nil;
-        }
-
-        // Save singleton
-        if (sharedClient == nil) {
-            sharedClient = self;
         }
     }
 


### PR DESCRIPTION
This allows one to create a separate client instance without worrying if the client instance will be set as the singleton. The class still supports a singleton, but must be explicitly set.

In addition, this uses the instancetype return types for better complier inference.

Fixes #41