### PR TITLE
Add Debug-Mode to Raven

### DIFF
--- a/Raven/RavenClient.h
+++ b/Raven/RavenClient.h
@@ -45,6 +45,7 @@ typedef enum {
 @property (strong, nonatomic) NSDictionary *tags;
 @property (strong, nonatomic) NSString *logger;
 @property (strong, nonatomic) NSDictionary *user;
+@property (assign, nonatomic) BOOL debugMode;
 
 /**
  * By setting tags with setTags: selector it will also set default settings:

--- a/Raven/RavenClient.m
+++ b/Raven/RavenClient.m
@@ -385,6 +385,11 @@ void exceptionHandler(NSException *exception) {
 }
 
 - (void)sendJSON:(NSData *)JSON {
+    if (self.debugMode == YES) {
+        NSLog(@"Sentry JSON (will not be sent in Debug Mode):\n%@\n",
+              [[NSString alloc] initWithData:JSON encoding:NSUTF8StringEncoding]);
+        return;
+    }
     NSString *header = [NSString stringWithFormat:@"Sentry sentry_version=%@, sentry_client=%@, sentry_timestamp=%ld, sentry_key=%@, sentry_secret=%@",
                         sentryProtocol,
                         sentryClient,


### PR DESCRIPTION
Add a simple way to put Raven in "Debug Mode" - basically a way prevent it from sending messages to the server  - but still allow Raven to handle exceptions and messages as-normal.

This prevents exceptions/messages during Development Cycles from cluttering up the Sentry stream - as well as being able to debug values for Messages that are sent to Raven.

Example Usage:
````
    [RavenClient clientWithDSN:@"XYZ"];
#ifdef DEBUG
    [RavenClient sharedClient].debugMode = YES;
#endif
    [[RavenClient sharedClient] setupExceptionHandler];
````

NSLog Output:
```
Sentry JSON (will not be sent in Debug Mode):
[JSON BODY]
```