### PR TITLE
Add macro define RAVEN_RELEASE_VERSION

### DIFF
--- a/Raven/Raven.h
+++ b/Raven/Raven.h
@@ -9,5 +9,10 @@
 #import <Raven/RavenClient.h>
 #import <Raven/RavenConfig.h>
 
+/**
+    IF YOU DON'T WANT TO TRACK ANYMORE, COMMENT THIS LINE.
+ */
+//#define     RAVEN_RELEASE_VERSION      (123)
+
 FOUNDATION_EXPORT double RavenVersionNumber;
 FOUNDATION_EXPORT const unsigned char RavenVersionString[];

--- a/Raven/Raven.h
+++ b/Raven/Raven.h
@@ -12,7 +12,7 @@
 /**
     IF YOU DON'T WANT TO TRACK ANYMORE, COMMENT THIS LINE.
  */
-//#define     RAVEN_RELEASE_VERSION      (123)
+#define     RAVEN_RELEASE_VERSION      (123)
 
 FOUNDATION_EXPORT double RavenVersionNumber;
 FOUNDATION_EXPORT const unsigned char RavenVersionString[];

--- a/Raven/RavenClient.m
+++ b/Raven/RavenClient.m
@@ -56,7 +56,12 @@ void exceptionHandler(NSException *exception) {
     NSMutableDictionary *mTags = [[NSMutableDictionary alloc] initWithDictionary:tags];
 
     if (withDefaultValues && ![mTags objectForKey:@"Build version"]) {
+        //VERSION
         NSString *buildVersion = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleShortVersionString"];
+        
+        //BUILD
+        buildVersion = [buildVersion stringByAppendingString:[NSString stringWithFormat:@"---Build: %@", [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleVersion"]]];
+        
         if (buildVersion) {
             [mTags setObject:buildVersion forKey:@"Build version"];
         }
@@ -385,6 +390,8 @@ void exceptionHandler(NSException *exception) {
 }
 
 - (void)sendJSON:(NSData *)JSON {
+    
+#ifdef RAVEN_RELEASE_VERSION
     if (!self.config) {
         NSLog(@"Sentry JSON (DSN not configured, will not be sent):\n%@\n",
               [[NSString alloc] initWithData:JSON encoding:NSUTF8StringEncoding]);
@@ -413,6 +420,7 @@ void exceptionHandler(NSException *exception) {
              NSLog(@"Connection failed! Error - %@ %@", [connectionError localizedDescription], [[connectionError userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey]);
         }
     }];
+#endif
 }
 
 #pragma mark - JSON helpers


### PR DESCRIPTION
1. Add macro define RAVEN_RELEASE_VERSION so that developers can control to track or not now
2. Add '--Build: xxxx'  to tag "Build version",  so that developers can focus on the build quickly