### PR TITLE
Upgrade to support Xcode 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: objective-c
+osx_image: xcode7.1
+xcode_project: Raven.xcodeproj
+xcode_scheme: RavenTests
+xcode_target: RavenTests
+xcode_sdk: iphonesimulator

--- a/Example/Raven-Info.plist
+++ b/Example/Raven-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>nl.mixedCase.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Raven.xcodeproj/project.pbxproj
+++ b/Raven.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 		0A46FEAE156FA72300D97F26 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A46FEAD156FA72300D97F26 /* AppDelegate.m */; };
 		0A46FEB1156FA72300D97F26 /* MainStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0A46FEAF156FA72300D97F26 /* MainStoryboard.storyboard */; };
 		0A46FEB4156FA72300D97F26 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A46FEB3156FA72300D97F26 /* ViewController.m */; };
-		0A46FEBC156FA72300D97F26 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A46FEBB156FA72300D97F26 /* SenTestingKit.framework */; };
 		0A46FEBD156FA72300D97F26 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A46FE9D156FA72300D97F26 /* UIKit.framework */; };
 		0A46FEBE156FA72300D97F26 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A46FE9F156FA72300D97F26 /* Foundation.framework */; };
 		0A46FEC6156FA72300D97F26 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 0A46FEC4156FA72300D97F26 /* InfoPlist.strings */; };
@@ -52,8 +51,7 @@
 		0A46FEB0156FA72300D97F26 /* en */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = en; path = en.lproj/MainStoryboard.storyboard; sourceTree = "<group>"; };
 		0A46FEB2156FA72300D97F26 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		0A46FEB3156FA72300D97F26 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
-		0A46FEBA156FA72300D97F26 /* RavenTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RavenTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		0A46FEBB156FA72300D97F26 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
+		0A46FEBA156FA72300D97F26 /* RavenTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RavenTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A46FEC3156FA72300D97F26 /* RavenTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "RavenTests-Info.plist"; sourceTree = "<group>"; };
 		0A46FEC5156FA72300D97F26 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		0A46FEC7156FA72300D97F26 /* RavenClientTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RavenClientTest.h; sourceTree = "<group>"; };
@@ -85,7 +83,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0A46FEBC156FA72300D97F26 /* SenTestingKit.framework in Frameworks */,
 				0A46FEBD156FA72300D97F26 /* UIKit.framework in Frameworks */,
 				0A46FEBE156FA72300D97F26 /* Foundation.framework in Frameworks */,
 			);
@@ -119,7 +116,7 @@
 			isa = PBXGroup;
 			children = (
 				0A46FE99156FA72300D97F26 /* RavenExample.app */,
-				0A46FEBA156FA72300D97F26 /* RavenTests.octest */,
+				0A46FEBA156FA72300D97F26 /* RavenTests.xctest */,
 				1DA6EDF91A6E0A6C00F2510C /* Raven.framework */,
 			);
 			name = Products;
@@ -131,7 +128,6 @@
 				0A46FE9D156FA72300D97F26 /* UIKit.framework */,
 				0A46FE9F156FA72300D97F26 /* Foundation.framework */,
 				0A46FEA1156FA72300D97F26 /* CoreGraphics.framework */,
-				0A46FEBB156FA72300D97F26 /* SenTestingKit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -253,8 +249,8 @@
 			);
 			name = RavenTests;
 			productName = RavenTests;
-			productReference = 0A46FEBA156FA72300D97F26 /* RavenTests.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
+			productReference = 0A46FEBA156FA72300D97F26 /* RavenTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		1DA6EDF81A6E0A6C00F2510C /* Raven (iOS) */ = {
 			isa = PBXNativeTarget;
@@ -280,8 +276,8 @@
 		0A46FE90156FA72300D97F26 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastTestingUpgradeCheck = 0620;
-				LastUpgradeCheck = 0620;
+				LastTestingUpgradeCheck = 0710;
+				LastUpgradeCheck = 0710;
 				ORGANIZATIONNAME = Gangverk;
 				TargetAttributes = {
 					1DA6EDF81A6E0A6C00F2510C = {
@@ -430,8 +426,10 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -468,6 +466,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
@@ -492,6 +491,7 @@
 				GCC_VERSION = "";
 				INFOPLIST_FILE = "Example/Raven-Info.plist";
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.mixedCase.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -505,6 +505,7 @@
 				GCC_PREFIX_HEADER = "Example/Raven-Prefix.pch";
 				GCC_VERSION = "";
 				INFOPLIST_FILE = "Example/Raven-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.mixedCase.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -515,18 +516,20 @@
 			buildSettings = {
 				BUNDLE_LOADER = "";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(DEVELOPER_LIBRARY_DIR)/Frameworks",
+					"${inherited}",
+					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Example/Raven-Prefix.pch";
 				GCC_VERSION = "";
 				INFOPLIST_FILE = "RavenTests/RavenTests-Info.plist";
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.mixedCase.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
 		};
@@ -535,17 +538,19 @@
 			buildSettings = {
 				BUNDLE_LOADER = "";
 				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(DEVELOPER_LIBRARY_DIR)/Frameworks",
+					"${inherited}",
+					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
+					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Example/Raven-Prefix.pch";
 				GCC_VERSION = "";
 				INFOPLIST_FILE = "RavenTests/RavenTests-Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.mixedCase.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
 		};
@@ -581,6 +586,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.mixedCase.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Raven;
 				SKIP_INSTALL = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -617,6 +623,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "nl.mixedCase.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = Raven;
 				SKIP_INSTALL = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Raven.xcodeproj/xcshareddata/xcschemes/Raven (iOS).xcscheme
+++ b/Raven.xcodeproj/xcshareddata/xcschemes/Raven (iOS).xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1DA6EDF81A6E0A6C00F2510C"
+               BuildableName = "Raven.framework"
+               BlueprintName = "Raven (iOS)"
+               ReferencedContainer = "container:Raven.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A46FEB9156FA72300D97F26"
+               BuildableName = "RavenTests.xctest"
+               BlueprintName = "RavenTests"
+               ReferencedContainer = "container:Raven.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1DA6EDF81A6E0A6C00F2510C"
+            BuildableName = "Raven.framework"
+            BlueprintName = "Raven (iOS)"
+            ReferencedContainer = "container:Raven.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1DA6EDF81A6E0A6C00F2510C"
+            BuildableName = "Raven.framework"
+            BlueprintName = "Raven (iOS)"
+            ReferencedContainer = "container:Raven.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1DA6EDF81A6E0A6C00F2510C"
+            BuildableName = "Raven.framework"
+            BlueprintName = "Raven (iOS)"
+            ReferencedContainer = "container:Raven.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Raven.xcodeproj/xcshareddata/xcschemes/RavenTests.xcscheme
+++ b/Raven.xcodeproj/xcshareddata/xcschemes/RavenTests.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A46FEB9156FA72300D97F26"
+               BuildableName = "RavenTests.octest"
+               BlueprintName = "RavenTests"
+               ReferencedContainer = "container:Raven.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A46FEB9156FA72300D97F26"
+               BuildableName = "RavenTests.xctest"
+               BlueprintName = "RavenTests"
+               ReferencedContainer = "container:Raven.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A46FEB9156FA72300D97F26"
+            BuildableName = "RavenTests.octest"
+            BlueprintName = "RavenTests"
+            ReferencedContainer = "container:Raven.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A46FEB9156FA72300D97F26"
+            BuildableName = "RavenTests.octest"
+            BlueprintName = "RavenTests"
+            ReferencedContainer = "container:Raven.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Raven/Info.plist
+++ b/Raven/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>nl.mixedCase.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Raven/RavenClient.m
+++ b/Raven/RavenClient.m
@@ -126,7 +126,7 @@ void exceptionHandler(NSException *exception) {
         _extra = extra;
         _logger = logger;
         self.tags = tags;
-        
+
         // Parse DSN
         if (_config && ![_config setDSN:DSN]) {
             NSLog(@"Invalid DSN %@!", DSN);
@@ -163,7 +163,7 @@ void exceptionHandler(NSException *exception) {
                 method:(const char *)method
                   file:(const char *)file
                   line:(NSInteger)line {
-    
+
     [self captureMessage:message level:level additionalExtra:additionalExtra additionalTags:additionalTags method:method file:file line:line sendNow:YES];
 }
 
@@ -175,7 +175,7 @@ void exceptionHandler(NSException *exception) {
                   file:(const char *)file
                   line:(NSInteger)line
                sendNow:(BOOL)sendNow {
-    
+
     NSArray *stacktrace;
     NSString *culprit;
     if (method && file && line) {
@@ -186,12 +186,12 @@ void exceptionHandler(NSException *exception) {
                                methodString, @"function",
                                [NSNumber numberWithInteger:line], @"lineno",
                                nil];
-        
+
         stacktrace = [NSArray arrayWithObject:frame];
 
         culprit = [NSString stringWithFormat:@"%@ / %@", filename, methodString];
     }
-    
+
     NSDictionary *data = [self prepareDictionaryForMessage:message
                                                      level:level
                                            additionalExtra:additionalExtra
@@ -199,7 +199,7 @@ void exceptionHandler(NSException *exception) {
                                                    culprit:culprit
                                                 stacktrace:stacktrace
                                                  exception:nil];
-    
+
     if (!sendNow) {
         // We can't send this message to Sentry now, e.g. because the error was network related and the user may not have a data connection So, save it into NSUserDefaults.
         NSArray *reports = [[NSUserDefaults standardUserDefaults] objectForKey:userDefaultsKey];
@@ -371,7 +371,7 @@ void exceptionHandler(NSException *exception) {
             extra, @"extra",
             tags, @"tags",
             self.logger ?: @"", @"logger",
-            
+
             message, @"message",
             culprit ?: @"", @"culprit",
             stacktraceDict, @"stacktrace",
@@ -390,7 +390,7 @@ void exceptionHandler(NSException *exception) {
               [[NSString alloc] initWithData:JSON encoding:NSUTF8StringEncoding]);
         return;
     }
-    
+
     NSString *header = [NSString stringWithFormat:@"Sentry sentry_version=%@, sentry_client=%@, sentry_timestamp=%ld, sentry_key=%@, sentry_secret=%@",
                         sentryProtocol,
                         sentryClient,

--- a/RavenTests/RavenClientTest.h
+++ b/RavenTests/RavenClientTest.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2012 Gangverk. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import "RavenClient_Private.h"
 
 
@@ -18,7 +18,7 @@
 @end
 
 
-@interface RavenClientTest : SenTestCase
+@interface RavenClientTest : XCTestCase
 
 @property MockRavenClient *client;
 

--- a/RavenTests/RavenClientTest.m
+++ b/RavenTests/RavenClientTest.m
@@ -37,7 +37,7 @@ NSString *const testDSN = @"http://public:secret@example.com/foo";
 - (void)testGenerateUUID
 {
     NSString *uuid = [self.client generateUUID];
-    STAssertEquals([uuid length], (NSUInteger)32, @"Invalid value for UUID returned: %@", uuid);
+    XCTAssertEqual([uuid length], (NSUInteger)32, @"Invalid value for UUID returned: %@", uuid);
 }
 
 - (void)testCaptureMessageWithOnlyMessage
@@ -45,16 +45,16 @@ NSString *const testDSN = @"http://public:secret@example.com/foo";
     [self.client captureMessage:@"An example message"];
     NSDictionary *lastEvent = self.client.lastEvent;
     NSArray *keys = [lastEvent allKeys];
-    STAssertTrue([keys containsObject:@"event_id"], @"Missing event_id");
-    STAssertTrue([keys containsObject:@"message"], @"Missing message");
-    STAssertTrue([keys containsObject:@"project"], @"Missing project");
-    STAssertTrue([keys containsObject:@"level"], @"Missing level");
-    STAssertTrue([keys containsObject:@"timestamp"], @"Missing timestamp");
-    STAssertEquals([lastEvent valueForKey:@"message"], @"An example message",
+    XCTAssertTrue([keys containsObject:@"event_id"], @"Missing event_id");
+    XCTAssertTrue([keys containsObject:@"message"], @"Missing message");
+    XCTAssertTrue([keys containsObject:@"project"], @"Missing project");
+    XCTAssertTrue([keys containsObject:@"level"], @"Missing level");
+    XCTAssertTrue([keys containsObject:@"timestamp"], @"Missing timestamp");
+    XCTAssertEqual([lastEvent valueForKey:@"message"], @"An example message",
                  @"Invalid value for message: %@", [lastEvent valueForKey:@"message"]);
-    STAssertEquals([lastEvent valueForKey:@"project"], self.client.config.projectId,
+    XCTAssertEqual([lastEvent valueForKey:@"project"], self.client.config.projectId,
                    @"Invalid value for project: %@", [lastEvent valueForKey:@"project"]);
-    STAssertTrue([[lastEvent valueForKey:@"level"] isEqualToString:@"info"],
+    XCTAssertTrue([[lastEvent valueForKey:@"level"] isEqualToString:@"info"],
                    @"Invalid value for level: %@", [lastEvent valueForKey:@"level"]);
 }
 
@@ -63,19 +63,19 @@ NSString *const testDSN = @"http://public:secret@example.com/foo";
     [self.client captureMessage:@"An example message" level:kRavenLogLevelDebugWarning];
     NSDictionary *lastEvent = self.client.lastEvent;
     NSArray *keys = [lastEvent allKeys];
-    STAssertTrue([keys containsObject:@"event_id"], @"Missing event_id");
-    STAssertTrue([keys containsObject:@"message"], @"Missing message");
-    STAssertTrue([keys containsObject:@"project"], @"Missing project");
-    STAssertTrue([keys containsObject:@"level"], @"Missing level");
-    STAssertTrue([keys containsObject:@"timestamp"], @"Missing timestamp");
-    STAssertTrue([keys containsObject:@"platform"], @"Missing platform");
-    STAssertEquals([lastEvent valueForKey:@"message"], @"An example message",
+    XCTAssertTrue([keys containsObject:@"event_id"], @"Missing event_id");
+    XCTAssertTrue([keys containsObject:@"message"], @"Missing message");
+    XCTAssertTrue([keys containsObject:@"project"], @"Missing project");
+    XCTAssertTrue([keys containsObject:@"level"], @"Missing level");
+    XCTAssertTrue([keys containsObject:@"timestamp"], @"Missing timestamp");
+    XCTAssertTrue([keys containsObject:@"platform"], @"Missing platform");
+    XCTAssertEqual([lastEvent valueForKey:@"message"], @"An example message",
                    @"Invalid value for message: %@", [lastEvent valueForKey:@"message"]);
-    STAssertEquals([lastEvent valueForKey:@"project"], self.client.config.projectId,
+    XCTAssertEqual([lastEvent valueForKey:@"project"], self.client.config.projectId,
                    @"Invalid value for project: %@", [lastEvent valueForKey:@"project"]);
-    STAssertTrue([[lastEvent valueForKey:@"level"] isEqualToString:@"warning"],
+    XCTAssertTrue([[lastEvent valueForKey:@"level"] isEqualToString:@"warning"],
                  @"Invalid value for level: %@", [lastEvent valueForKey:@"level"]);
-    STAssertEquals([lastEvent valueForKey:@"platform"], @"objc",
+    XCTAssertEqual([lastEvent valueForKey:@"platform"], @"objc",
                    @"Invalid value for platform: %@", [lastEvent valueForKey:@"platform"]);
 }
 
@@ -86,20 +86,20 @@ NSString *const testDSN = @"http://public:secret@example.com/foo";
                          method:"method name" file:"filename" line:34];
     NSDictionary *lastEvent = self.client.lastEvent;
     NSArray *keys = [lastEvent allKeys];
-    STAssertTrue([keys containsObject:@"event_id"], @"Missing event_id");
-    STAssertTrue([keys containsObject:@"message"], @"Missing message");
-    STAssertTrue([keys containsObject:@"project"], @"Missing project");
-    STAssertTrue([keys containsObject:@"level"], @"Missing level");
-    STAssertTrue([keys containsObject:@"timestamp"], @"Missing timestamp");
-    STAssertTrue([keys containsObject:@"platform"], @"Missing platform");
-    STAssertTrue([keys containsObject:@"stacktrace"], @"Missing stacktrace");
-    STAssertEquals([lastEvent valueForKey:@"message"], @"An example message",
+    XCTAssertTrue([keys containsObject:@"event_id"], @"Missing event_id");
+    XCTAssertTrue([keys containsObject:@"message"], @"Missing message");
+    XCTAssertTrue([keys containsObject:@"project"], @"Missing project");
+    XCTAssertTrue([keys containsObject:@"level"], @"Missing level");
+    XCTAssertTrue([keys containsObject:@"timestamp"], @"Missing timestamp");
+    XCTAssertTrue([keys containsObject:@"platform"], @"Missing platform");
+    XCTAssertTrue([keys containsObject:@"stacktrace"], @"Missing stacktrace");
+    XCTAssertEqual([lastEvent valueForKey:@"message"], @"An example message",
                    @"Invalid value for message: %@", [lastEvent valueForKey:@"message"]);
-    STAssertEquals([lastEvent valueForKey:@"project"], self.client.config.projectId,
+    XCTAssertEqual([lastEvent valueForKey:@"project"], self.client.config.projectId,
                    @"Invalid value for project: %@", [lastEvent valueForKey:@"project"]);
-    STAssertTrue([[lastEvent valueForKey:@"level"] isEqualToString:@"warning"],
+    XCTAssertTrue([[lastEvent valueForKey:@"level"] isEqualToString:@"warning"],
                  @"Invalid value for level: %@", [lastEvent valueForKey:@"level"]);
-    STAssertEquals([lastEvent valueForKey:@"platform"], @"objc",
+    XCTAssertEqual([lastEvent valueForKey:@"platform"], @"objc",
                    @"Invalid value for platform: %@", [lastEvent valueForKey:@"platform"]);
 }
 
@@ -112,25 +112,25 @@ NSString *const testDSN = @"http://public:secret@example.com/foo";
 
     NSDictionary *lastEvent = self.client.lastEvent;
     NSArray *keys = [lastEvent allKeys];
-    STAssertTrue([keys containsObject:@"event_id"], @"Missing event_id");
-    STAssertTrue([keys containsObject:@"message"], @"Missing message");
-    STAssertTrue([keys containsObject:@"project"], @"Missing project");
-    STAssertTrue([keys containsObject:@"level"], @"Missing level");
-    STAssertTrue([keys containsObject:@"timestamp"], @"Missing timestamp");
-    STAssertTrue([keys containsObject:@"platform"], @"Missing platform");
-    STAssertTrue([keys containsObject:@"extra"], @"Missing extra");
-    STAssertTrue([keys containsObject:@"tags"], @"Missing tags");
+    XCTAssertTrue([keys containsObject:@"event_id"], @"Missing event_id");
+    XCTAssertTrue([keys containsObject:@"message"], @"Missing message");
+    XCTAssertTrue([keys containsObject:@"project"], @"Missing project");
+    XCTAssertTrue([keys containsObject:@"level"], @"Missing level");
+    XCTAssertTrue([keys containsObject:@"timestamp"], @"Missing timestamp");
+    XCTAssertTrue([keys containsObject:@"platform"], @"Missing platform");
+    XCTAssertTrue([keys containsObject:@"extra"], @"Missing extra");
+    XCTAssertTrue([keys containsObject:@"tags"], @"Missing tags");
 
-    STAssertEquals([lastEvent[@"extra"] objectForKey:@"key"], @"extra value", @"Missing extra data");
-    STAssertEquals([lastEvent[@"tags"] objectForKey:@"key"], @"tag value", @"Missing tags data");
+    XCTAssertEqual([lastEvent[@"extra"] objectForKey:@"key"], @"extra value", @"Missing extra data");
+    XCTAssertEqual([lastEvent[@"tags"] objectForKey:@"key"], @"tag value", @"Missing tags data");
 
-    STAssertEquals([lastEvent valueForKey:@"message"], @"An example message",
+    XCTAssertEqual([lastEvent valueForKey:@"message"], @"An example message",
                    @"Invalid value for message: %@", [lastEvent valueForKey:@"message"]);
-    STAssertEquals([lastEvent valueForKey:@"project"], self.client.config.projectId,
+    XCTAssertEqual([lastEvent valueForKey:@"project"], self.client.config.projectId,
                    @"Invalid value for project: %@", [lastEvent valueForKey:@"project"]);
-    STAssertTrue([[lastEvent valueForKey:@"level"] isEqualToString:@"warning"],
+    XCTAssertTrue([[lastEvent valueForKey:@"level"] isEqualToString:@"warning"],
                  @"Invalid value for level: %@", [lastEvent valueForKey:@"level"]);
-    STAssertEquals([lastEvent valueForKey:@"platform"], @"objc",
+    XCTAssertEqual([lastEvent valueForKey:@"platform"], @"objc",
                    @"Invalid value for platform: %@", [lastEvent valueForKey:@"platform"]);
 }
 
@@ -148,16 +148,16 @@ NSString *const testDSN = @"http://public:secret@example.com/foo";
     NSDictionary *lastEvent = client.lastEvent;
     NSArray *keys = [lastEvent allKeys];
 
-    STAssertTrue([keys containsObject:@"extra"], @"Missing extra");
-    STAssertTrue([keys containsObject:@"tags"], @"Missing tags");
-    STAssertEquals([lastEvent[@"extra"] objectForKey:@"key"], @"value", @"Missing extra data");
-    STAssertEquals([lastEvent[@"tags"] objectForKey:@"key"], @"value", @"Missing tags data");
+    XCTAssertTrue([keys containsObject:@"extra"], @"Missing extra");
+    XCTAssertTrue([keys containsObject:@"tags"], @"Missing tags");
+    XCTAssertEqual([lastEvent[@"extra"] objectForKey:@"key"], @"value", @"Missing extra data");
+    XCTAssertEqual([lastEvent[@"tags"] objectForKey:@"key"], @"value", @"Missing tags data");
 
-    STAssertEquals([lastEvent[@"extra"] objectForKey:@"key2"], @"extra value", @"Missing extra data");
-    STAssertEquals([lastEvent[@"tags"] objectForKey:@"key2"], @"tag value", @"Missing tags data");
+    XCTAssertEqual([lastEvent[@"extra"] objectForKey:@"key2"], @"extra value", @"Missing extra data");
+    XCTAssertEqual([lastEvent[@"tags"] objectForKey:@"key2"], @"tag value", @"Missing tags data");
 
-    STAssertNotNil([lastEvent[@"tags"] objectForKey:@"OS version"], @"Missing tags data");
-    STAssertNotNil([lastEvent[@"tags"] objectForKey:@"Device model"], @"Missing tags data");
+    XCTAssertNotNil([lastEvent[@"tags"] objectForKey:@"OS version"], @"Missing tags data");
+    XCTAssertNotNil([lastEvent[@"tags"] objectForKey:@"Device model"], @"Missing tags data");
 }
 
 - (void)testClientWithRewritingExtraAndTags
@@ -174,11 +174,11 @@ NSString *const testDSN = @"http://public:secret@example.com/foo";
     NSDictionary *lastEvent = client.lastEvent;
     NSArray *keys = [lastEvent allKeys];
 
-    STAssertTrue([keys containsObject:@"extra"], @"Missing extra");
-    STAssertTrue([keys containsObject:@"tags"], @"Missing tags");
+    XCTAssertTrue([keys containsObject:@"extra"], @"Missing extra");
+    XCTAssertTrue([keys containsObject:@"tags"], @"Missing tags");
 
-    STAssertEquals([lastEvent[@"extra"] objectForKey:@"key"], @"extra value", @"Missing extra data");
-    STAssertEquals([lastEvent[@"tags"] objectForKey:@"key"], @"tag value", @"Missing tags data");
+    XCTAssertEqual([lastEvent[@"extra"] objectForKey:@"key"], @"extra value", @"Missing extra data");
+    XCTAssertEqual([lastEvent[@"tags"] objectForKey:@"key"], @"tag value", @"Missing tags data");
 }
 
 - (void)testClientWithLogger
@@ -192,9 +192,9 @@ NSString *const testDSN = @"http://public:secret@example.com/foo";
     
     NSDictionary *lastEvent = client.lastEvent;
 
-    STAssertEquals([lastEvent valueForKey:@"message"], @"An example message",
+    XCTAssertEqual([lastEvent valueForKey:@"message"], @"An example message",
                    @"Invalid value for message: %@", [lastEvent valueForKey:@"message"]);
-    STAssertEquals([lastEvent valueForKey:@"logger"], @"Logger value",
+    XCTAssertEqual([lastEvent valueForKey:@"logger"], @"Logger value",
                    @"Invalid value for logger: %@", [lastEvent valueForKey:@"logger"]);
 
 }
@@ -208,12 +208,12 @@ NSString *const testDSN = @"http://public:secret@example.com/foo";
     NSDictionary *lastEvent = client.lastEvent;
 
     NSArray *keys = [lastEvent allKeys];
-    STAssertTrue([keys containsObject:@"user"], @"Missing user");
+    XCTAssertTrue([keys containsObject:@"user"], @"Missing user");
 
-    STAssertEquals([lastEvent[@"user"] objectForKey:@"username"], @"timor", @"Missing username");
-    STAssertEquals([lastEvent[@"user"] objectForKey:@"ip_address"], @"127.0.0.1", @"Missing ip address");
+    XCTAssertEqual([lastEvent[@"user"] objectForKey:@"username"], @"timor", @"Missing username");
+    XCTAssertEqual([lastEvent[@"user"] objectForKey:@"ip_address"], @"127.0.0.1", @"Missing ip address");
 
-    STAssertEquals([lastEvent valueForKey:@"message"], @"An example message",
+    XCTAssertEqual([lastEvent valueForKey:@"message"], @"An example message",
                    @"Invalid value for message: %@", [lastEvent valueForKey:@"message"]);
 }
 
@@ -227,12 +227,12 @@ NSString *const testDSN = @"http://public:secret@example.com/foo";
     NSDictionary *lastEvent = client.lastEvent;
     
     NSArray *keys = [lastEvent allKeys];
-    STAssertTrue([keys containsObject:@"user"], @"Missing user");
+    XCTAssertTrue([keys containsObject:@"user"], @"Missing user");
     
-    STAssertEquals([lastEvent[@"user"] objectForKey:@"username"], @"timor", @"Missing username");
-    STAssertEquals([lastEvent[@"user"] objectForKey:@"ip_address"], @"127.0.0.1", @"Missing ip address");
+    XCTAssertEqual([lastEvent[@"user"] objectForKey:@"username"], @"timor", @"Missing username");
+    XCTAssertEqual([lastEvent[@"user"] objectForKey:@"ip_address"], @"127.0.0.1", @"Missing ip address");
     
-    STAssertEquals([lastEvent valueForKey:@"message"], @"An example message",
+    XCTAssertEqual([lastEvent valueForKey:@"message"], @"An example message",
                    @"Invalid value for message: %@", [lastEvent valueForKey:@"message"]);
 }
 

--- a/RavenTests/RavenConfigTest.h
+++ b/RavenTests/RavenConfigTest.h
@@ -6,8 +6,8 @@
 //  Copyright (c) 2012 Gangverk. All rights reserved.
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface RavenConfigTest : SenTestCase
+@interface RavenConfigTest : XCTestCase
 
 @end

--- a/RavenTests/RavenConfigTest.m
+++ b/RavenTests/RavenConfigTest.m
@@ -16,15 +16,15 @@
     RavenConfig *config = [RavenConfig alloc];
     BOOL didParse = [config setDSN:@"http://public_key:secret_key@example.com:8000/project-id"];
     
-    STAssertTrue(didParse, @"Failed to parse DSN");
+    XCTAssertTrue(didParse, @"Failed to parse DSN");
     
-    STAssertTrue([config.publicKey isEqualToString:@"public_key"], @"Got incorrect publicKey %@", config.publicKey);
-    STAssertTrue([config.secretKey isEqualToString:@"secret_key"], @"Got incorrect secretKey %@", config.secretKey);
-    STAssertTrue([config.projectId isEqualToString:@"project-id"], @"Got incorrect projectId %@", config.projectId);
+    XCTAssertTrue([config.publicKey isEqualToString:@"public_key"], @"Got incorrect publicKey %@", config.publicKey);
+    XCTAssertTrue([config.secretKey isEqualToString:@"secret_key"], @"Got incorrect secretKey %@", config.secretKey);
+    XCTAssertTrue([config.projectId isEqualToString:@"project-id"], @"Got incorrect projectId %@", config.projectId);
     
     NSString *expectedURL = @"http://example.com:8000/api/project-id/store/";
     
-    STAssertTrue([[config.serverURL absoluteString] isEqualToString:expectedURL], @"Got incorrect serverURL %@", [config.serverURL absoluteString]);
+    XCTAssertTrue([[config.serverURL absoluteString] isEqualToString:expectedURL], @"Got incorrect serverURL %@", [config.serverURL absoluteString]);
 }
 
 - (void)testSetDSNWithSSLPortUndefined
@@ -32,15 +32,15 @@
     RavenConfig *config = [RavenConfig alloc];
     BOOL didParse = [config setDSN:@"https://public_key:secret_key@example.com/project-id"];
     
-    STAssertTrue(didParse, @"Failed to parse DSN");
+    XCTAssertTrue(didParse, @"Failed to parse DSN");
     
-    STAssertTrue([config.publicKey isEqualToString:@"public_key"], @"Got incorrect publicKey %@", config.publicKey);
-    STAssertTrue([config.secretKey isEqualToString:@"secret_key"], @"Got incorrect secretKey %@", config.secretKey);
-    STAssertTrue([config.projectId isEqualToString:@"project-id"], @"Got incorrect projectId %@", config.projectId);
+    XCTAssertTrue([config.publicKey isEqualToString:@"public_key"], @"Got incorrect publicKey %@", config.publicKey);
+    XCTAssertTrue([config.secretKey isEqualToString:@"secret_key"], @"Got incorrect secretKey %@", config.secretKey);
+    XCTAssertTrue([config.projectId isEqualToString:@"project-id"], @"Got incorrect projectId %@", config.projectId);
     
     NSString *expectedURL = @"https://example.com:443/api/project-id/store/";
     
-    STAssertTrue([[config.serverURL absoluteString] isEqualToString:expectedURL], @"Got incorrect serverURL %@", [config.serverURL absoluteString]);
+    XCTAssertTrue([[config.serverURL absoluteString] isEqualToString:expectedURL], @"Got incorrect serverURL %@", [config.serverURL absoluteString]);
 }
 
 - (void)testSetDSNWithoutSSLPortUndefined
@@ -48,15 +48,15 @@
     RavenConfig *config = [RavenConfig alloc];
     BOOL didParse = [config setDSN:@"http://public_key:secret_key@example.com/project-id"];
     
-    STAssertTrue(didParse, @"Failed to parse DSN");
+    XCTAssertTrue(didParse, @"Failed to parse DSN");
     
-    STAssertTrue([config.publicKey isEqualToString:@"public_key"], @"Got incorrect publicKey %@", config.publicKey);
-    STAssertTrue([config.secretKey isEqualToString:@"secret_key"], @"Got incorrect secretKey %@", config.secretKey);
-    STAssertTrue([config.projectId isEqualToString:@"project-id"], @"Got incorrect projectId %@", config.projectId);
+    XCTAssertTrue([config.publicKey isEqualToString:@"public_key"], @"Got incorrect publicKey %@", config.publicKey);
+    XCTAssertTrue([config.secretKey isEqualToString:@"secret_key"], @"Got incorrect secretKey %@", config.secretKey);
+    XCTAssertTrue([config.projectId isEqualToString:@"project-id"], @"Got incorrect projectId %@", config.projectId);
     
     NSString *expectedURL = @"http://example.com:80/api/project-id/store/";
     
-    STAssertTrue([[config.serverURL absoluteString] isEqualToString:expectedURL], @"Got incorrect serverURL %@", [config.serverURL absoluteString]);
+    XCTAssertTrue([[config.serverURL absoluteString] isEqualToString:expectedURL], @"Got incorrect serverURL %@", [config.serverURL absoluteString]);
 }
 
 

--- a/RavenTests/RavenTests-Info.plist
+++ b/RavenTests/RavenTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>nl.mixedCase.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/bin/test
+++ b/bin/test
@@ -1,6 +1,9 @@
-xcodebuild \
-  -scheme RavenTests \
-  -target RavenTests \
-  -sdk iphonesimulator \
-  -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.1' \
-  test
+#!/bin/bash -eu
+
+FLAGS="-scheme RavenTests -target RavenTests -sdk iphonesimulator"
+
+if [ -e $(which xcpretty) ]; then
+    xcodebuild $FLAGS test | xcpretty --color
+else
+    xcodebuild $FLAGS test
+fi

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,6 @@
+xcodebuild \
+  -scheme RavenTests \
+  -target RavenTests \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.1' \
+  test


### PR DESCRIPTION
This upgrades to support the latest version of Xcode which also converts from SenTest to XCTest.

Additionally I added a simple bin/test helper to help people like myself have some clue of how this world should work.

My primary concern with these changes is if they break support for older versions of iOS/Xcode (and if it matters). I believe our target should be iOS 8+.