### PR TITLE
Increase Swift support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ lesterkp - https://github.com/lesterkp
 Christoph Lupprich - https://github.com/clupprich
 Dmitry Vorobyov - https://github.com/dvor
 Mark Anderson - https://github.com/manderson-productions
+Benjamin Horsleben - https://github.com/fizker

--- a/Raven/RavenClient.h
+++ b/Raven/RavenClient.h
@@ -42,10 +42,10 @@ typedef enum {
 
 @interface RavenClient : NSObject
 
-@property (strong, nonatomic) NSDictionary *extra;
-@property (strong, nonatomic) NSDictionary *tags;
+@property (strong, nonatomic) NSDictionary<NSString*,NSString*> *extra;
+@property (strong, nonatomic) NSDictionary<NSString*,NSString*> *tags;
 @property (strong, nonatomic, nullable) NSString *logger;
-@property (strong, nonatomic, nullable) NSDictionary *user;
+@property (strong, nonatomic, nullable) NSDictionary<NSString*,NSString*> *user;
 @property (assign, nonatomic) BOOL debugMode;
 
 /**
@@ -56,23 +56,23 @@ typedef enum {
  *
  * For full control use this method.
  */
-- (void)setTags:(NSDictionary *)tags withDefaultValues:(BOOL)withDefaultValues;
+- (void)setTags:(NSDictionary<NSString*,NSString*> *)tags withDefaultValues:(BOOL)withDefaultValues;
 
 - (void)setRelease:(nullable NSString *)release;
 
 // Singleton and initializers
 + (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN;
-+ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra;
-+ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags;
-+ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags logger:(nullable NSString *)logger;
++ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra;
++ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags;
++ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags logger:(nullable NSString *)logger;
 
 + (nullable instancetype)sharedClient;
 + (void)setSharedClient:(nullable RavenClient *)client;
 
 - (nullable instancetype)initWithDSN:(nullable NSString *)DSN;
-- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra;
-- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags;
-- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags logger:(nullable NSString *)logger;
+- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra;
+- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags;
+- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags logger:(nullable NSString *)logger;
 
 /**
  * Messages
@@ -85,20 +85,20 @@ typedef enum {
 - (void)captureMessage:(NSString *)message;
 - (void)captureMessage:(NSString *)message level:(RavenLogLevel)level;
 - (void)captureMessage:(NSString *)message level:(RavenLogLevel)level method:(nullable const char *)method file:(nullable const char *)file line:(NSInteger)line;
-- (void)captureMessage:(NSString *)message level:(RavenLogLevel)level additionalExtra:(nullable NSDictionary *)additionalExtra additionalTags:(nullable NSDictionary *)additionalTags;
+- (void)captureMessage:(NSString *)message level:(RavenLogLevel)level additionalExtra:(nullable NSDictionary<NSString*,NSString*> *)additionalExtra additionalTags:(nullable NSDictionary<NSString*,NSString*> *)additionalTags;
 
 - (void)captureMessage:(NSString *)message
                  level:(RavenLogLevel)level
-       additionalExtra:(nullable NSDictionary *)additionalExtra
-        additionalTags:(nullable NSDictionary *)additionalTags
+       additionalExtra:(nullable NSDictionary<NSString*,NSString*> *)additionalExtra
+        additionalTags:(nullable NSDictionary<NSString*,NSString*> *)additionalTags
                 method:(nullable const char *)method
                   file:(nullable const char *)file
                   line:(NSInteger)line;
 
 - (void)captureMessage:(NSString *)message
                  level:(RavenLogLevel)level
-       additionalExtra:(nullable NSDictionary *)additionalExtra
-        additionalTags:(nullable NSDictionary *)additionalTags
+       additionalExtra:(nullable NSDictionary<NSString*,NSString*> *)additionalExtra
+        additionalTags:(nullable NSDictionary<NSString*,NSString*> *)additionalTags
                 method:(nullable const char *)method
                   file:(nullable const char *)file
                   line:(NSInteger)line
@@ -114,7 +114,7 @@ typedef enum {
  */
 - (void)captureException:(NSException *)exception;
 - (void)captureException:(NSException *)exception sendNow:(BOOL)sendNow;
-- (void)captureException:(NSException *)exception additionalExtra:(nullable NSDictionary *)additionalExtra additionalTags:(nullable NSDictionary *)additionalTags sendNow:(BOOL)sendNow;
+- (void)captureException:(NSException *)exception additionalExtra:(nullable NSDictionary<NSString*,NSString*> *)additionalExtra additionalTags:(nullable NSDictionary<NSString*,NSString*> *)additionalTags sendNow:(BOOL)sendNow;
 - (void)captureException:(NSException*)exception method:(nullable const char*)method file:(nullable const char*)file line:(NSInteger)line sendNow:(BOOL)sendNow;
 - (void)setupExceptionHandler;
 

--- a/Raven/RavenClient.h
+++ b/Raven/RavenClient.h
@@ -42,7 +42,7 @@ typedef enum {
 
 @interface RavenClient : NSObject
 
-@property (strong, nonatomic) NSDictionary<NSString*,NSString*> *extra;
+@property (strong, nonatomic) NSDictionary<NSString*,NSObject*> *extra;
 @property (strong, nonatomic) NSDictionary<NSString*,NSString*> *tags;
 @property (strong, nonatomic, nullable) NSString *logger;
 @property (strong, nonatomic, nullable) NSDictionary<NSString*,NSString*> *user;
@@ -62,17 +62,17 @@ typedef enum {
 
 // Singleton and initializers
 + (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN;
-+ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra;
-+ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags;
-+ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags logger:(nullable NSString *)logger;
++ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSObject*> *)extra;
++ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSObject*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags;
++ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSObject*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags logger:(nullable NSString *)logger;
 
 + (nullable instancetype)sharedClient;
 + (void)setSharedClient:(nullable RavenClient *)client;
 
 - (nullable instancetype)initWithDSN:(nullable NSString *)DSN;
-- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra;
-- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags;
-- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSString*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags logger:(nullable NSString *)logger;
+- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSObject*> *)extra;
+- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSObject*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags;
+- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary<NSString*,NSObject*> *)extra tags:(NSDictionary<NSString*,NSString*> *)tags logger:(nullable NSString *)logger;
 
 /**
  * Messages
@@ -85,11 +85,11 @@ typedef enum {
 - (void)captureMessage:(NSString *)message;
 - (void)captureMessage:(NSString *)message level:(RavenLogLevel)level;
 - (void)captureMessage:(NSString *)message level:(RavenLogLevel)level method:(nullable const char *)method file:(nullable const char *)file line:(NSInteger)line;
-- (void)captureMessage:(NSString *)message level:(RavenLogLevel)level additionalExtra:(nullable NSDictionary<NSString*,NSString*> *)additionalExtra additionalTags:(nullable NSDictionary<NSString*,NSString*> *)additionalTags;
+- (void)captureMessage:(NSString *)message level:(RavenLogLevel)level additionalExtra:(nullable NSDictionary<NSString*,NSObject*> *)additionalExtra additionalTags:(nullable NSDictionary<NSString*,NSString*> *)additionalTags;
 
 - (void)captureMessage:(NSString *)message
                  level:(RavenLogLevel)level
-       additionalExtra:(nullable NSDictionary<NSString*,NSString*> *)additionalExtra
+       additionalExtra:(nullable NSDictionary<NSString*,NSObject*> *)additionalExtra
         additionalTags:(nullable NSDictionary<NSString*,NSString*> *)additionalTags
                 method:(nullable const char *)method
                   file:(nullable const char *)file
@@ -97,7 +97,7 @@ typedef enum {
 
 - (void)captureMessage:(NSString *)message
                  level:(RavenLogLevel)level
-       additionalExtra:(nullable NSDictionary<NSString*,NSString*> *)additionalExtra
+       additionalExtra:(nullable NSDictionary<NSString*,NSObject*> *)additionalExtra
         additionalTags:(nullable NSDictionary<NSString*,NSString*> *)additionalTags
                 method:(nullable const char *)method
                   file:(nullable const char *)file
@@ -114,7 +114,7 @@ typedef enum {
  */
 - (void)captureException:(NSException *)exception;
 - (void)captureException:(NSException *)exception sendNow:(BOOL)sendNow;
-- (void)captureException:(NSException *)exception additionalExtra:(nullable NSDictionary<NSString*,NSString*> *)additionalExtra additionalTags:(nullable NSDictionary<NSString*,NSString*> *)additionalTags sendNow:(BOOL)sendNow;
+- (void)captureException:(NSException *)exception additionalExtra:(nullable NSDictionary<NSString*,NSObject*> *)additionalExtra additionalTags:(nullable NSDictionary<NSString*,NSString*> *)additionalTags sendNow:(BOOL)sendNow;
 - (void)captureException:(NSException*)exception method:(nullable const char*)method file:(nullable const char*)file line:(NSInteger)line sendNow:(BOOL)sendNow;
 - (void)setupExceptionHandler;
 

--- a/Raven/RavenClient.h
+++ b/Raven/RavenClient.h
@@ -29,6 +29,7 @@
 
 #define RavenCaptureException(exception) [[RavenClient sharedClient] captureException:exception method:__FUNCTION__ file:__FILE__ line:__LINE__ sendNow:YES];
 
+NS_ASSUME_NONNULL_BEGIN
 
 typedef enum {
     kRavenLogLevelDebug,
@@ -43,8 +44,8 @@ typedef enum {
 
 @property (strong, nonatomic) NSDictionary *extra;
 @property (strong, nonatomic) NSDictionary *tags;
-@property (strong, nonatomic) NSString *logger;
-@property (strong, nonatomic) NSDictionary *user;
+@property (strong, nonatomic, nullable) NSString *logger;
+@property (strong, nonatomic, nullable) NSDictionary *user;
 @property (assign, nonatomic) BOOL debugMode;
 
 /**
@@ -57,21 +58,21 @@ typedef enum {
  */
 - (void)setTags:(NSDictionary *)tags withDefaultValues:(BOOL)withDefaultValues;
 
-- (void)setRelease:(NSString *)release;
+- (void)setRelease:(nullable NSString *)release;
 
 // Singleton and initializers
-+ (RavenClient *)clientWithDSN:(NSString *)DSN;
-+ (RavenClient *)clientWithDSN:(NSString *)DSN extra:(NSDictionary *)extra;
-+ (RavenClient *)clientWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags;
-+ (RavenClient *)clientWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags logger:(NSString *)logger;
++ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN;
++ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra;
++ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags;
++ (nullable RavenClient *)clientWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags logger:(nullable NSString *)logger;
 
-+ (instancetype)sharedClient;
-+ (void)setSharedClient:(RavenClient *)client;
++ (nullable instancetype)sharedClient;
++ (void)setSharedClient:(nullable RavenClient *)client;
 
-- (instancetype)initWithDSN:(NSString *)DSN;
-- (instancetype)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra;
-- (instancetype)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags;
-- (instancetype)initWithDSN:(NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags logger:(NSString *)logger;
+- (nullable instancetype)initWithDSN:(nullable NSString *)DSN;
+- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra;
+- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags;
+- (nullable instancetype)initWithDSN:(nullable NSString *)DSN extra:(NSDictionary *)extra tags:(NSDictionary *)tags logger:(nullable NSString *)logger;
 
 /**
  * Messages
@@ -83,23 +84,23 @@ typedef enum {
  */
 - (void)captureMessage:(NSString *)message;
 - (void)captureMessage:(NSString *)message level:(RavenLogLevel)level;
-- (void)captureMessage:(NSString *)message level:(RavenLogLevel)level method:(const char *)method file:(const char *)file line:(NSInteger)line;
-- (void)captureMessage:(NSString *)message level:(RavenLogLevel)level additionalExtra:(NSDictionary *)additionalExtra additionalTags:(NSDictionary *)additionalTags;
+- (void)captureMessage:(NSString *)message level:(RavenLogLevel)level method:(nullable const char *)method file:(nullable const char *)file line:(NSInteger)line;
+- (void)captureMessage:(NSString *)message level:(RavenLogLevel)level additionalExtra:(nullable NSDictionary *)additionalExtra additionalTags:(nullable NSDictionary *)additionalTags;
 
 - (void)captureMessage:(NSString *)message
                  level:(RavenLogLevel)level
-       additionalExtra:(NSDictionary *)additionalExtra
-        additionalTags:(NSDictionary *)additionalTags
-                method:(const char *)method
-                  file:(const char *)file
+       additionalExtra:(nullable NSDictionary *)additionalExtra
+        additionalTags:(nullable NSDictionary *)additionalTags
+                method:(nullable const char *)method
+                  file:(nullable const char *)file
                   line:(NSInteger)line;
 
 - (void)captureMessage:(NSString *)message
                  level:(RavenLogLevel)level
-       additionalExtra:(NSDictionary *)additionalExtra
-        additionalTags:(NSDictionary *)additionalTags
-                method:(const char *)method
-                  file:(const char *)file
+       additionalExtra:(nullable NSDictionary *)additionalExtra
+        additionalTags:(nullable NSDictionary *)additionalTags
+                method:(nullable const char *)method
+                  file:(nullable const char *)file
                   line:(NSInteger)line
                sendNow:(BOOL)sendNow;
 
@@ -113,8 +114,10 @@ typedef enum {
  */
 - (void)captureException:(NSException *)exception;
 - (void)captureException:(NSException *)exception sendNow:(BOOL)sendNow;
-- (void)captureException:(NSException *)exception additionalExtra:(NSDictionary *)additionalExtra additionalTags:(NSDictionary *)additionalTags sendNow:(BOOL)sendNow;
-- (void)captureException:(NSException*)exception method:(const char*)method file:(const char*)file line:(NSInteger)line sendNow:(BOOL)sendNow;
+- (void)captureException:(NSException *)exception additionalExtra:(nullable NSDictionary *)additionalExtra additionalTags:(nullable NSDictionary *)additionalTags sendNow:(BOOL)sendNow;
+- (void)captureException:(NSException*)exception method:(nullable const char*)method file:(nullable const char*)file line:(NSInteger)line sendNow:(BOOL)sendNow;
 - (void)setupExceptionHandler;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Raven/RavenConfig.h
+++ b/Raven/RavenConfig.h
@@ -8,13 +8,17 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface RavenConfig : NSObject
 
 - (BOOL)setDSN:(NSString *)DSN;
 
-@property (strong, nonatomic) NSURL *serverURL;
-@property (strong, nonatomic) NSString *publicKey;
-@property (strong, nonatomic) NSString *secretKey;
-@property (strong, nonatomic) NSString *projectId;
+@property (strong, nonatomic, nullable) NSURL *serverURL;
+@property (strong, nonatomic, nullable) NSString *publicKey;
+@property (strong, nonatomic, nullable) NSString *secretKey;
+@property (strong, nonatomic, nullable) NSString *projectId;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
I added nullability annotations and generic types for the dictionaries. This makes the compiler help you regardless of language, and makes the project much more usable from Swift.

I made some guesses on `null` and the `<NSString *, NSString *>` dictionaries based on the code and the tests, so there is a chance that the annotations are wrong ;).

The one downside is that it requires Xcode 7 to understand the annotations.
