### PR TITLE
Updated NSURLConnection to NSURLSession

### DIFF
--- a/Raven/RavenClient.m
+++ b/Raven/RavenClient.m
@@ -429,14 +429,17 @@ void exceptionHandler(NSException *exception) {
     [request setValue:[NSString stringWithFormat:@"%lu", (unsigned long)[JSON length]] forHTTPHeaderField:@"Content-Length"];
     [request setHTTPBody:JSON];
     [request setValue:header forHTTPHeaderField:@"X-Sentry-Auth"];
-
-    [NSURLConnection sendAsynchronousRequest:request queue:[NSOperationQueue currentQueue] completionHandler:^(NSURLResponse *response, NSData *data, NSError *connectionError) {
+    
+    [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        
         if (data) {
-        	NSLog(@"JSON sent to Sentry");
+            NSLog(@"JSON sent to Sentry");
         } else {
-             NSLog(@"Connection failed! Error - %@ %@", [connectionError localizedDescription], [[connectionError userInfo] objectForKey:NSURLErrorFailingURLStringErrorKey]);
+            NSLog(@"Connection failed! Error - %@ %@", [error localizedDescription], [error userInfo][NSURLErrorFailingURLStringErrorKey]);
         }
-    }];
+        
+    }] resume];
+    
 }
 
 #pragma mark - JSON helpers


### PR DESCRIPTION
NSURLConnection was deprecated in iOS 9 - Apple now recommends using NSURLSession.

It looks like this was originally submitted [here](https://github.com/getsentry/raven-objc/pull/72) and was closed for some reason. If there is some issue with this change, please let me know!
